### PR TITLE
Hotfix/correcciones varias

### DIFF
--- a/classes/models/homologation/Image.php
+++ b/classes/models/homologation/Image.php
@@ -60,9 +60,9 @@ class Image extends AbstractHomologation {
    */
   protected function create() {
     $db = \Db::getInstance();
-    $sql = "INSERT INTO `" . _DB_PREFIX_ . static::$TABLE
-            . "` (`id`, `id_centry`,`fingerprint`)"
-            . " VALUES (" . ((int) $this->id) . ", '"
+    $sql = "INSERT INTO `" . static::tableName()
+            . "` (`id_prestashop`, `id_centry`, `fingerprint`)"
+            . " VALUES (" . ((int) $this->id_prestashop) . ", '"
             . $db->escape($this->id_centry) . "', '"
             . $db->escape($this->fingerprint) . "')";
     return $db->execute($sql) != false;

--- a/classes/translators/Products.php
+++ b/classes/translators/Products.php
@@ -610,6 +610,16 @@ class Products {
     }
     $attributes = self::Attributes($combination_ps, $variant, $sync);
     $combination_ps->setAttributes($attributes);
+
+    if ($sync["product_images"] && is_array($variant->assets) && count($variant->assets)) {
+      $images_ids = [];
+      foreach ($variant->assets as $asset) {
+        $image_id = \CentryPs\models\homologation\Image::getIdPrestashop($asset->_id);
+        if ($image_id) array_push($images_ids, ['id' => $image_id]);
+      }
+      if (count($images_ids)) $combination_ps->setWsImages($images_ids);
+    }
+
     try {
       $combination_ps->save();
     } catch (\Exception $ex) {

--- a/controllers/front/abstracttaskprocessor.php
+++ b/controllers/front/abstracttaskprocessor.php
@@ -49,7 +49,7 @@ abstract class AbstractTaskProcessor extends ModuleFrontController {
       'topic' => "'{$this->topic}'",
       'resource_id' => "'{$id}'"
     ];
-    return PendingTask::getPendingTasksObjects($conditions, 1, 0)[0];
+    return PendingTask::getPendingTasksObjects($conditions, 1)[0];
   }
 
   /**

--- a/controllers/front/centryproductsave.php
+++ b/controllers/front/centryproductsave.php
@@ -25,6 +25,12 @@ class Centry_Ps_EsclavoCentryProductSaveModuleFrontController extends AbstractTa
       throw new Exception('Resource is not a Centry model.');
     }
 
+    $resp->assets = $centry->sdk()->getProductImages($product_id);
+    foreach($resp->variants as $variant) {
+      $params = array('variant_id' => $variant->_id);
+      $variant->assets = $centry->sdk()->getProductVariantImages($product_id, $params);
+    }
+
     if (($id = CentryPs\models\homologation\Product::getIdPrestashop($resp->_id))) {
       //Actualizacion
       $product_ps = new \Product($id);
@@ -41,5 +47,4 @@ class Centry_Ps_EsclavoCentryProductSaveModuleFrontController extends AbstractTa
       $product_centry->save();
     }
   }
-
 }

--- a/override/classes/Combination.php
+++ b/override/classes/Combination.php
@@ -1,0 +1,79 @@
+<?php
+
+/*
+ * La clase Combination de Prestashop presentaba un bug al momento de actualizar el
+ * valor de una combinación, eliminando innecesariamente la combinación de todos los
+ * carritos de compra de los usuarios. A partir de la versión 1.7.8.0 de Prestashop
+ * se corrigió el bug.
+ * 
+ * Link al PR donde se corrige: https://github.com/PrestaShop/PrestaShop/pull/23081
+ * 
+ * Para aquellas versiones de Prestashop que presentan el bug, se sobreescriben los
+ * metodos necesarios para lograr la misma solución dada por el autor del PR. Para
+ * las versiones que no presentan el bug, se utiliza el método original.
+ */
+
+class Combination extends CombinationCore {
+  public function delete() {
+    if (Tools::version_compare(_PS_VERSION_, '1.7.8', '>=')) {
+      return parent::delete();
+    }
+
+    if (!parent::delete()) {
+      return false;
+    }
+
+    StockAvailable::removeProductFromStockAvailable((int) $this->id_product, (int) $this->id);
+
+    if ($specificPrices = SpecificPrice::getByProductId((int) $this->id_product, (int) $this->id)) {
+        foreach ($specificPrices as $specificPrice) {
+            $price = new SpecificPrice((int) $specificPrice['id_specific_price']);
+            $price->delete();
+        }
+    }
+
+    if (!$this->hasMultishopEntries() && !$this->deleteAssociations()) {
+        return false;
+    }
+
+    if (!$this->deleteCartProductCombination()) {
+        return false;
+    }
+
+    $this->deleteFromSupplier($this->id_product);
+    Product::updateDefaultAttribute($this->id_product);
+    Tools::clearColorListCache((int) $this->id_product);
+
+    return true;
+  }
+
+  public function deleteAssociations() {
+    if (Tools::version_compare(_PS_VERSION_, '1.7.8', '>=')) {
+      return parent::deleteAssociations();
+    }
+
+    if ((int) $this->id === 0) {
+      return false;
+    }
+    $result = Db::getInstance()->delete('product_attribute_combination', '`id_product_attribute` = ' . (int) $this->id);
+    $result &= Db::getInstance()->delete('product_attribute_image', '`id_product_attribute` = ' . (int) $this->id);
+
+    if ($result) {
+        Hook::exec('actionAttributeCombinationDelete', ['id_product_attribute' => (int) $this->id]);
+    }
+
+    return $result;
+  }
+
+  protected function deleteCartProductCombination(): bool {
+    if (Tools::version_compare(_PS_VERSION_, '1.7.8', '>=')) {
+      return parent::deleteCartProductCombination();
+    }
+
+    if ((int) $this->id === 0) {
+        return false;
+    }
+
+    return Db::getInstance()->delete('cart_product', 'id_product_attribute = ' . (int) $this->id);
+  }
+}

--- a/sdk/CentrySDK.php
+++ b/sdk/CentrySDK.php
@@ -219,13 +219,37 @@ class CentrySDK {
   }
 
   /**
-   * Obitene producto en Centry.
+   * Obtiene producto en Centry.
    * @param $product_id
    * @param null $params
    * @return mixed|string
    */
   public function getProduct($product_id, $params = null) {
     return $this->get("conexion/v1/products/" . $product_id . ".json", $params);
+  }
+
+  /**
+   * Obtiene las imagenes asociadas a un producto en Centry.
+   * @param $product_id
+   * @param null $params
+   * @return mixed|string
+   */
+  public function getProductImages($product_id, $params = null) {
+    return $this->get("conexion/v1/products/" . $product_id . "/assets.json", $params);
+  }
+
+  /**
+   * Obtiene las imagenes asociadas a una variante de un producto en Centry.
+   * @param $product_id
+   * @param $params variant_id
+   * @return mixed|string
+   */
+  public function getProductVariantImages($product_id, $params = null) {
+    if (isset($params['variant_id'])) {
+      return $this->get("conexion/v1/products/" . $product_id . "/assets.json", $params);
+    }
+
+    return [];
   }
 
   /**


### PR DESCRIPTION
Se realizan 4 cambios principales:

1. Se priorizan las tareas pendientes provenientes de PrestaShop.
2. Se corrige la creación de la homologación de imágenes y se refactoriza la sección del código que las crea para que la imagen principal y el resto de las imágenes utilicen el mismo método de creación.
3. Se asocian las imágenes de las variantes de Centry a una combinación en PrestaShop.
4. Se arregla el bug de los productos que desaparecen de los carritos de compra al ser actualizados. Se usa la misma solución que acepto la comunidad de PrestaShop.