### PR TITLE
Configuración de descripción corta.

### DIFF
--- a/centry_ps_esclavo.php
+++ b/centry_ps_esclavo.php
@@ -372,7 +372,7 @@ class Centry_PS_esclavo extends Module {
    */
   private function saveSynchronizationCheckboxes() {
     $fields = [
-      'name', 'price', 'priceoffer', 'description', 'skuproduct',
+      'name', 'price', 'priceoffer', 'description', 'shortdescription', 'skuproduct',
       'characteristics', 'warranty', 'condition', 'status', 'stock',
       'variantsku', 'size', 'color', 'barcode', 'productimages', 'seo', 'brand',
       'package', 'category'
@@ -404,13 +404,27 @@ class Centry_PS_esclavo extends Module {
   public function displayForm() {
     $defaultLang = (int) Configuration::get('PS_LANG_DEFAULT');
 
-    $sync_fields = [["id" => "name", 'name' => "Nombre"], ["id" => "price", 'name' => "Precio"], ["id" => "priceoffer", 'name' => "Precio de oferta"],
-      ["id" => "description", 'name' => "Descripción"], ["id" => "skuproduct", 'name' => "Sku del Producto"], ["id" => "characteristics", 'name' => "Características"],
-      ["id" => "stock", 'name' => "Stock"], ["id" => "variantsku", 'name' => "Sku de la Variante"], ["id" => "size", 'name' => "Talla"],
-      ["id" => "color", 'name' => "Color"], ["id" => "barcode", 'name' => "Código de barras (Tiene que ser valores válidos. Si no estás seguro, mejor no los mantengas sincronizados.)"], ["id" => "productimages", 'name' => "Imágenes Producto"],
-      ["id" => "condition", 'name' => "Condición"], ["id" => "warranty", 'name' => "Garantía"], ["id" => "status", 'name' => "Estado"],
-      ["id" => "seo", 'name' => "Campos SEO"], ["id" => "brand", 'name' => "Marca"], ["id" => "package", 'name' => "Medidas del paquete"],
-      ["id" => "category", 'name' => "Categoría"]];
+    $sync_fields = [
+      ["id" => "name", 'name' => "Nombre"],
+      ["id" => "price", 'name' => "Precio"],
+      ["id" => "priceoffer", 'name' => "Precio de oferta"],
+      ["id" => "description", 'name' => "Descripción"],
+      ["id" => "shortdescription", 'name' => "Descripción corta (Listado de características)"],
+      ["id" => "skuproduct", 'name' => "Sku del Producto"],
+      ["id" => "characteristics", 'name' => "Características"],
+      ["id" => "stock", 'name' => "Stock"],
+      ["id" => "variantsku", 'name' => "Sku de la Variante"],
+      ["id" => "size", 'name' => "Talla"],
+      ["id" => "color", 'name' => "Color"],
+      ["id" => "barcode", 'name' => "Código de barras (Tiene que ser valores válidos. Si no estás seguro, mejor no los mantengas sincronizados.)"],
+      ["id" => "productimages", 'name' => "Imágenes Producto"],
+      ["id" => "condition", 'name' => "Condición"], ["id" => "warranty", 'name' => "Garantía"],
+      ["id" => "status", 'name' => "Estado"],
+      ["id" => "seo", 'name' => "Campos SEO"],
+      ["id" => "brand", 'name' => "Marca"],
+      ["id" => "package", 'name' => "Medidas del paquete"],
+      ["id" => "category", 'name' => "Categoría"]
+    ];
 
     // Init Fields form array
     $fieldsForm[0]['form'] = array(

--- a/classes/ConfigurationCentry.php
+++ b/classes/ConfigurationCentry.php
@@ -120,6 +120,22 @@ class ConfigurationCentry {
   }
 
   /**
+   *  Creación o actualización del campo descripción corta (características) en la base de datos para su sincronizacion en la creación de un producto.
+   * @param $value Indica si se utiliza la descripción corta (características) para la creación del producto.
+   */
+  public static function setSyncOnCreateShortDescription($value) {
+    \Configuration::updateValue("CENTRY_SYNC_ONCREATE_shortdescription", $value);
+  }
+
+  /**
+   * Creación o actualización del campo descripción corta (características) en la base de datos para su sincronizacion en la actualización de un producto.
+   * @param $value Indica si se utiliza la descripción corta (características) para la actualización del producto.
+   */
+  public static function setSyncOnUpdateShortDescription($value) {
+    \Configuration::updateValue("CENTRY_SYNC_ONCREATE_shortdescription", $value);
+  }
+
+  /**
    * Función que obtiene el valor de la base de datos del campo descripcion para la creación de un producto.
    * @return string valor que indica si el campo descripcion se utiliza para la creación de un producto.
    */
@@ -133,6 +149,22 @@ class ConfigurationCentry {
    */
   public static function getSyncOnUpdateDescription() {
     return \Configuration::get("CENTRY_SYNC_ONUPDATE_description", null, null, null, 'on');
+  }
+
+  /**
+   * Función que obtiene el valor de la base de datos del campo descripción corta (características) para la creación de un producto.
+   * @return string valor que indica si el campo descripcion se utiliza para la creación de un producto.
+   */
+  public static function getSyncOnCreateShortDescription() {
+    return \Configuration::get("CENTRY_SYNC_ONCREATE_shortdescription", null, null, null, 'on');
+  }
+
+  /**
+   * Función que obtiene el valor de la base de datos del campo descripción corta (características para la actualización de un producto.
+   * @return string valor que indica si el campo descripcion se utiliza para la actualización de un producto.
+   */
+  public static function getSyncOnUpdateShortDescription() {
+    return \Configuration::get("CENTRY_SYNC_ONUPDATE_shortdescription", null, null, null, 'on');
   }
 
   /**
@@ -674,6 +706,7 @@ class ConfigurationCentry {
     $sync["price_offer"] = ConfigurationCentry::getSyncOnUpdatePriceOffer();
     $sync["characteristics"] = ConfigurationCentry::getSyncOnUpdateCharacteristics();
     $sync["description"] = ConfigurationCentry::getSyncOnUpdateDescription();
+    $sync["shortdescription"] = ConfigurationCentry::getSyncOnUpdateShortDescription();
     $sync["sku_product"] = ConfigurationCentry::getSyncOnUpdateSkuProduct();
     $sync["stock"] = ConfigurationCentry::getSyncOnUpdateStock();
     $sync["size"] = ConfigurationCentry::getSyncOnUpdateSize();
@@ -703,6 +736,7 @@ class ConfigurationCentry {
     $sync["price_offer"] = ConfigurationCentry::getSyncOnCreatePriceOffer();
     $sync["characteristics"] = ConfigurationCentry::getSyncOnCreateCharacteristics();
     $sync["description"] = ConfigurationCentry::getSyncOnCreateDescription();
+    $sync["shortdescription"] = ConfigurationCentry::getSyncOnCreateShortDescription();
     $sync["sku_product"] = ConfigurationCentry::getSyncOnCreateSkuProduct();
     $sync["stock"] = ConfigurationCentry::getSyncOnCreateStock();
     $sync["size"] = ConfigurationCentry::getSyncOnCreateSize();

--- a/classes/translators/Products.php
+++ b/classes/translators/Products.php
@@ -18,6 +18,7 @@ class Products {
     $product_ps->reference = $sync["sku_product"] ? mb_substr($product->sku, 0, 64) : $product_ps->reference;
     $product_ps->active = $sync["status"] ? $product->status : $product_ps->active;
     $product_ps->description = ($sync["description"] && property_exists($product, "description")) ? $product->description : $product_ps->description;
+    $product_ps->description_short = ($sync["shortdescription"] && property_exists($product, "shortdescription")) ? $product->shortdescription : $product_ps->description_short;
     $product_ps->condition = $sync["condition"] ? $product->condition : $product_ps->condition;
     $product_ps->width = ($sync["package"] && property_exists($product, "packagewidth")) ? $product->packagewidth : $product_ps->width;
     $product_ps->height = ($sync["package"] && property_exists($product, "packageheight")) ? $product->packageheight : $product_ps->height;


### PR DESCRIPTION
Se habilita una nueva configuración para controlar la sincronización del campo "descripción corta" o "listado de características".

Solución basada en el pull-request de @msaustral https://github.com/CentryCL/centry_ps_esclavo/pull/4/commits/c81b0777f63e3125505ac7c927ae8b2c02b9459b