### PR TITLE
Auto homologación de productos

### DIFF
--- a/classes/models/homologation/Product.php
+++ b/classes/models/homologation/Product.php
@@ -23,4 +23,28 @@ class Product extends AbstractHomologation {
       ALTER TABLE `{$table_name}` ADD FOREIGN KEY (`id_prestashop`) REFERENCES `" . _DB_PREFIX_ . "product" . "`(`id_product`) ON DELETE CASCADE ON UPDATE NO ACTION;";
   }
 
+  /**
+   * Busca un producto en PrestaShop por su SKU (`reference`) y retorna su
+   * identificador. Si encuentra uno, aprovecha de guardar el registro que
+   * relaciona el producto de PrestaShop con el Centry.
+   * @param  string $sku SKU del producto a buscar.
+   * @param  string $id_centry Identificador del producto en Centry.
+   * @return int     valor del id de prestashop.
+   */
+  public static function findIdPrestashopBySkuAndHomologate($sku, $id_centry) {
+    $db = \Db::getInstance();
+    $query = new \DbQuery();
+    $query->select('id_product');
+    $query->from('product');
+    $query->where("reference = '" . $db->escape($sku) . "'");
+    if (!($result = $db->executeS($query))) {
+      return null
+    }
+    $id_prestashop = $result[0]['id_product'];
+   
+    $product_centry = new CentryPs\models\homologation\Product($id_prestashop, $id_centry);
+    $product_centry->save();
+    return $id_prestashop;
+  }
+
 }

--- a/controllers/front/centryproductsave.php
+++ b/controllers/front/centryproductsave.php
@@ -10,7 +10,7 @@ use CentryPs\models\system\PendingTask;
 
 /**
  * Controlador encargado de ejecutar la tarea de leer un producto de Centry para
- * crearlo o actualizarlo en Prestashop.
+ * crearlo o actualizarlo en PrestaShop.
  */
 class Centry_Ps_EsclavoCentryProductSaveModuleFrontController extends AbstractTaskProcessor {
 
@@ -31,8 +31,8 @@ class Centry_Ps_EsclavoCentryProductSaveModuleFrontController extends AbstractTa
       $variant->assets = $centry->sdk()->getProductVariantImages($product_id, $params);
     }
 
-    if (($id = CentryPs\models\homologation\Product::getIdPrestashop($resp->_id))) {
-      //Actualizacion
+    if (($id = $this->findPrestaShopProductId(($resp->_id, ($resp->_id) CentryPs\models\homologation\Product::getIdPrestashop($resp->_id))) {
+      //Actualización
       $product_ps = new \Product($id);
       $sync = ConfigurationCentry::getSyncOnUpdate();
     } else {
@@ -46,5 +46,20 @@ class Centry_Ps_EsclavoCentryProductSaveModuleFrontController extends AbstractTa
       $product_centry = new CentryPs\models\homologation\Product($res->id, $resp->_id);
       $product_centry->save();
     }
+  }
+
+  /**
+   * Busca en la base de datos el id de un producto de PrestaShop que tenga por
+   * <code>centry_id</code> el pasado como parámetro o, si no hay un producto
+   * homologado, busca un producto por SKU y lo autohomologa.
+   * @param string $centry_id
+   * @param string $sku
+   * @return int
+   */
+  private function findPrestaShopProductId($centry_id, $sku) {
+    if (($id = CentryPs\models\homologation\Product::getIdPrestashop($resp->_id))) {
+      return $id;
+    }
+    return CentryPs\models\homologation\Product::findIdPrestashopBySkuAndHomologate($sku, $centry_id);
   }
 }


### PR DESCRIPTION
El recibir una notificación de tipo "on_product_save" si no existe una homologación de productos, se hace una búsqueda por SKU y se autohomologa antes de simplemente crear un nuevo producto.

Basado en el PR de @msaustral https://github.com/CentryCL/centry_ps_esclavo/commit/c81b0777f63e3125505ac7c927ae8b2c02b9459b