### PR TITLE
Correción en obtención de Tareas

### DIFF
--- a/classes/models/system/PendingTask.php
+++ b/classes/models/system/PendingTask.php
@@ -251,7 +251,7 @@ class PendingTask extends AbstractModel {
    * @return array
    */
   public static function getPendingTasks(array $conditions = null, int $limit = null) {
-    if (is_null($limit) || $limit == 0) {
+    if (is_null($limit)) {
       $prestashop_tasks = static::getPendingTasksByOrigin('prestashop', $conditions);
       $centry_tasks = static::getPendingTasksByOrigin('centry', $conditions);
       return array_merge($prestashop_tasks, $centry_tasks);


### PR DESCRIPTION
 #19 
Se quita condicional que  devuelve el total de tareas , ignorando máximo de hilos asignados al módulo